### PR TITLE
Cleanup database image

### DIFF
--- a/DOCKERFILE.db.development
+++ b/DOCKERFILE.db.development
@@ -1,13 +1,5 @@
 FROM postgres:9.6
 LABEL maintainer="M. Edward (Ed) Borasky <znmeb@znmeb.net>"
-# https://github.com/hackoregon/data-science-pet-containers/blob/master/containers/Dockerfile.postgis
-
-# Repo for up-to-date R
-COPY jessie/cran.list.jessie /etc/apt/sources.list.d/cran.list
-RUN apt-key adv --keyserver keys.gnupg.net --recv-key 'E19F5F87128899B192B1A2C2AD5F960A256A04AF'
-
-# Backports
-COPY jessie/backports.list.jessie /etc/apt/sources.list.d/backports.list
 
 # Install apt packages
 RUN apt-get update \
@@ -17,67 +9,19 @@ RUN apt-get update \
     postgresql-9.6-postgis-2.4-scripts \
     postgresql-9.6-postgis-scripts \
     postgresql-9.6-pgrouting \
-    postgresql-9.6-mysql-fdw \
-    postgresql-9.6-ogr-fdw \
-    postgresql-9.6-python3-multicorn \
-    awscli \
-    bash-completion \
-    build-essential \
-    bzip2 \
-    ca-certificates \
-    cmake \
-    command-not-found \
-    expat \
-    gdal-bin \
-    geotiff-bin \
-    git \
-    less \
-    libboost-dev \
-    libboost-program-options-dev \
-    libexpat1-dev \
-    libgdal-dev \
-    libgeotiff-dev \
-    libpq-dev \
-    libpqxx-dev \
-    librasterlite-dev \
-    libspatialite-dev \
-    libudunits2-dev \
-    openssh-client \
-    p7zip \
-    postgresql-client-9.6 \
-    proj-bin \
-    python-dev \
-    python3-dev \
-    python3-csvkit \
-    rasterlite-bin \
-    spatialite-bin \
-    tar \
-    udunits-bin \
-    unixodbc-dev \
-    unrar-free \
-    unzip \
-    wget \
-  && apt-get clean \
-  && apt-file update \
-  && update-command-not-found
+  && apt-get clean
 
 # copy the root scripts to /usr/local/src
-RUN mkdir -p /usr/local/src
 COPY postgis-root-scripts  /usr/local/src/
 RUN chmod +x /usr/local/src/*.bash
 
 # database superusers
-RUN useradd --shell /bin/bash --user-group --create-home dbsuper \
-  && mkdir -p /home/dbsuper/Projects
+RUN useradd --shell /bin/bash --user-group --create-home dbsuper
 ARG DB_USERS_TO_CREATE
-RUN bash /usr/local/src/make-dbusers-linux.bash \
-  && mkdir -p /gisdata \
-  && echo "alias l='ls -ACF --color=auto'" >> /etc/bash.bashrc \
-  && echo "alias ll='ls -ltrAF --color=auto'" >> /etc/bash.bashrc
+RUN bash /usr/local/src/make-dbusers-linux.bash
 
 # set up automatic restores and dbsuper home
 COPY postgis-scripts/1make-dbsuper.sh Backups/restore-all.sh /docker-entrypoint-initdb.d/
-RUN chmod +x /docker-entrypoint-initdb.d/*.sh \
-  && chown -R postgres:postgres /gisdata
+RUN chmod +x /docker-entrypoint-initdb.d/*.sh
 COPY Backups /home/dbsuper/Backups
 RUN chown -R dbsuper:dbsuper /home/dbsuper

--- a/development-docker-compose.yml
+++ b/development-docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - 5439:5432
     environment:
-      - POSTGRES_PASSWORD=sit-down-c0mic
+      - POSTGRES_PASSWORD=${DEVELOPMENT_POSTGRES_PASSWORD}
   api_development:
     build:
       context: .


### PR DESCRIPTION
This pull request cleans out all the extraneous packages from DOCKERFILE.db.development. It also closes issue #17 . I've tested it locally with `bin/build.sh -l` and `bin/start.sh -l`.