### PR TITLE
Update README.md to clarify process for creating and running a backend API application

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,49 +36,14 @@ API Related:
 
 * `gunicorn_config.py` - Config file for the gunicorn server
 
-## Run the Sample
-
-There is currently a Sample API included within the repo. To run:
-
-1. First `cd` into the root directory of your clone of the repo and run the command `cp env.sample .env`
-
-2. Build the development containers using the command: `./bin/build.sh -d`. If this script won't run, you may need to confirm you have executable perms on all the scripts in the `./bin` folder: `$ chmod +x ./bin/*.sh` Feel free to read each one and assign perms individually, 'cause it is your computer :stuck_out_tongue_winking_eye: and security is a real thing.
-
-3. Once this completes you will now want to start up the project. We will use the `start.sh` script for this, again using the `-d` flag to run locally:  `./bin/start.sh -d` The first time you run this you will see the database restores. You will also see the api container start up.
-
-4. Open your browser and you will be able to access the Django REST framework browserable front end. The IP address you use will depend on your Docker hosting:
-
-    * Windows 10 Pro + Docker for Windows, MacOS or Linux: API root `http://localhost:8000/api`, Swagger API schema `http://localhost:8000/schema`
-    * Docker Toolbox running on Windows or Mac: API root `http://MACHINE-IP:8000/api`, Swagger API schema `http://MACHINE-IP:8000/schema`
-
-        where `MACHINE-IP` is the IP address `docker-machine ip` returns.
-
-5. You can stop the container using Ctrl-C to stop the process in the terminal window.
-
-## Run the Tests
-
-This repo contains some tests for the Sample API. It will import a fixtures file containing example data that has been exported from the Django API using the `dumpdata` command:
-
-```
-./manage.py dumpdata --indent=2 -v 2 --traceback api > ./api/fixtures/songs.json
-```
-
-To run the tests:
-
-1. Run `./bin/test.sh -d` - this will load the fixtures and run tests.
-
-Currently this repo contains two type of tests:
-
-* Unit tests which verify the expected data types are returned
-* API tests, which verify correct status codes are returned when making calls to api endpoints
-
 ## Quickstart for your own API - Development
 
 Once you understand the sample you can create your own api. This repo contains a quickstart script that is intended to remove the sample app and quickly spin up a development repo. It is only intended to remove the sample application. It will not delete an api if it is already began. See Manual Setup steps below on how to manually remove an existing API and start or copy in your own.
 
 1. `cp env.sample .env` in the root of the repo (this file is already in the `.gitignore`, so you should not have to worry about it getting accidentally checked into a GitHub repo)
 
-2. Edit your `.env` file and change the `DEVELOPMENT_` variables to appropriate values for your project - feel free to ignore the `PRODUCTION_` variables for the moment:
+2. Edit your `.env` file and change the `DEVELOPMENT_` variables to appropriate values for your project's databasae backup - feel free to ignore the `PRODUCTION_` variables for the moment. Ensure that the values `PROJECT_NAME`, `DEVELOPMENT_POSTGRES_NAME`, and `DEVELOPMENT_DATABASE_OWNER` are set correctly. You should not need to change any of the other values. _If you unsure of what values to use for these settings or do not have a database backup file, please contact your Team's Data Manager before proceeding further._ 
+
 
 ```shell
 # MUST BE A DOCKER PROJECT NAME COMPLIANT NAME
@@ -92,6 +57,9 @@ DEVELOPMENT_POSTGRES_USER=postgres
 
 # the database name the API will connect to - "dbname" in most PostgreSQL command-line tools
 DEVELOPMENT_POSTGRES_NAME=<your_database_name>
+
+# the database owner - automatic restore needs this
+DEVELOPMENT_DATABASE_OWNER=<your_database_owner>
 
 # *service* name (*not* image name) of the database in the Docker network
 DEVELOPMENT_POSTGRES_HOST=db_development
@@ -112,9 +80,11 @@ DEVELOPMENT_DJANGO_SECRET_KEY=r0ck.ar0und.the.c10ck
 
 5. This would be a good point to instantiate a new Git history for the project going forward. You can remove the existing git by removing the hidden folder - make sure you are in the repo directory and run `rm -rf .git`. You can then run `git init` to start a new history and then add your remote branch.
 
-6. Create your api code. Checkout the [Django REST framework Guide](http://www.django-rest-framework.org/) on how to proceed.
+6. Run the `bin/build.sh` script to build the project. Since you are going to be running it on the local machine you will want to run: `./bin/build.sh -d`, this command is doing a docker-compose build in the background. It is downloading the images needed for the project to your local machine.
 
 7. Once this completes you will now want to start up the project. We will use the `start.sh` script for this, again using the `-d` flag to run locally:  `./bin/start.sh -d` The first time you run this you will see the database restores. You will also see the api container start up.
+
+8. Create your api code. Checkout the [Django REST framework Guide](http://www.django-rest-framework.org/) on how to proceed.
 
 ## Manually Setup an API - Development
 
@@ -152,6 +122,42 @@ ls -l
 6. There is a recommended settings.py file in the bin called `example_settings.py`. This is the basic current example which works with the intended python packages for both development and production. It is configured to pickup the os variables related to Django and the Database. In a new API you should be able to copy over the file, renaming and replacing the auto generated `settings.py`. After this, you can replace all occurances of `<EXAMPLE_PROJECT_NAME>` with your actual project name
 
 7. Continue with steps 5-7 of Quickstart guide to complete building the API
+
+## Run the Sample
+
+There is currently a Sample API included within the repo. To run:
+
+1. First `cd` into the root directory of your clone of the repo and run the command `cp env.sample .env`
+
+2. Build the development containers using the command: `./bin/build.sh -d`. If this script won't run, you may need to confirm you have executable perms on all the scripts in the `./bin` folder: `$ chmod +x ./bin/*.sh` Feel free to read each one and assign perms individually, 'cause it is your computer :stuck_out_tongue_winking_eye: and security is a real thing.
+
+3. Once this completes you will now want to start up the project. We will use the `start.sh` script for this, again using the `-d` flag to run locally:  `./bin/start.sh -d` The first time you run this you will see the database restores. You will also see the api container start up.
+
+4. Open your browser and you will be able to access the Django REST framework browserable front end. The IP address you use will depend on your Docker hosting:
+
+    * Windows 10 Pro + Docker for Windows, MacOS or Linux: API root `http://localhost:8000/api`, Swagger API schema `http://localhost:8000/schema`
+    * Docker Toolbox running on Windows or Mac: API root `http://MACHINE-IP:8000/api`, Swagger API schema `http://MACHINE-IP:8000/schema`
+
+        where `MACHINE-IP` is the IP address `docker-machine ip` returns.
+
+5. You can stop the container using Ctrl-C to stop the process in the terminal window.
+
+## Run the Tests
+
+This repo contains some tests for the Sample API. It will import a fixtures file containing example data that has been exported from the Django API using the `dumpdata` command:
+
+```
+./manage.py dumpdata --indent=2 -v 2 --traceback api > ./api/fixtures/songs.json
+```
+
+To run the tests:
+
+1. Run `./bin/test.sh -d` - this will load the fixtures and run tests.
+
+Currently this repo contains two type of tests:
+
+* Unit tests which verify the expected data types are returned
+* API tests, which verify correct status codes are returned when making calls to api endpoints
 
 ## Contributors and History
 


### PR DESCRIPTION
Move Run Sample API and Run Tests sections underneath Quickstart
Add missing DEVELOPMENT_POSTGRES_OWNER variable to example
Add more explanation about database .env settings
Add step explaining build.sh back in to Quickstart instructions