### PR TITLE
Removes redundant wait-for-it helper

### DIFF
--- a/DOCKERFILE.api.production
+++ b/DOCKERFILE.api.production
@@ -9,7 +9,6 @@ RUN apt-get update \
     binutils \
     gdal-bin \
     libproj-dev \
-    postgresql-client-9.6 \
   && apt-get clean
 
 # create and populate /code

--- a/bin/production-docker-entrypoint.sh
+++ b/bin/production-docker-entrypoint.sh
@@ -1,20 +1,8 @@
 #! /bin/bash
 
-# wait-for-postgres.sh
-# https://docs.docker.com/compose/startup-order/
-
 # http://linuxcommand.org/lc3_man_pages/seth.html:
 # -e  Exit immediately if a command exits with a non-zero status.
 set -e
-
-export PGPASSWORD=$POSTGRES_PASSWORD
-until psql -h "$POSTGRES_HOST" -U "$POSTGRES_USER" -p "$POSTGRES_PORT" -d "$POSTGRES_NAME" -c '\q'
-do
-  >&2 echo "Postgres is unavailable - sleeping"
-  sleep 5
-done
-
->&2 echo "Postgres is up"
 
 echo Debug: $DEBUG
 

--- a/bin/test-entrypoint.sh
+++ b/bin/test-entrypoint.sh
@@ -5,15 +5,6 @@ export PATH=$PATH:~/.local/bin
 # -e  Exit immediately if a command exits with a non-zero status.
 set -e
 
-export PGPASSWORD=$POSTGRES_PASSWORD
-until psql -h "$POSTGRES_HOST" -U "$POSTGRES_USER" -p "$POSTGRES_PORT" -d postgres -c '\q'
-do
-  >&2 echo "Postgres is unavailable - sleeping"
-  sleep 5
-done
-
->&2 echo "Postgres is up"
-
 # Collect static files
 echo "Collect static files"
 python -Wall manage.py collectstatic --noinput


### PR DESCRIPTION
I believe this is unnecessary in CI context, since tests will still fail if the database is unavailable, and since the database is very unlikely to fail transiently.  None of the 2017 database instances have even once rebooted in a year (as measured by the fact their non-permanent, non-EIP IP addresses have ever changed).  No evidence that they have ever gone unavailable for short or long periods either.