### PR TITLE
Add ENTRYPOINT script to DOCKERFILE

### DIFF
--- a/DOCKERFILE.api.production
+++ b/DOCKERFILE.api.production
@@ -23,3 +23,5 @@ RUN pip install -r geodjango.txt
 
 RUN python
 COPY . /code/
+
+ENTRYPOINT [ "/code/bin/production-docker-entrypoint.sh" ]


### PR DESCRIPTION
This is for use when ECS launches the bare container image - without the ENTRYPOINT script, all startup using `docker-compose` in the Travis environment will work fine, but when the container image is published, then deployed to ECS and finally launched by ECS, there is no `docker-compose` in use - only bare `docker` commands such as `docker run` (AFAIK).

We got bit by this last year for a while.

Addresses #64 