### PR TITLE
add rest_framework_gist to installed apps example settings

### DIFF
--- a/bin/example-settings.py
+++ b/bin/example-settings.py
@@ -44,6 +44,7 @@ if DEBUG == True:
         'corsheaders',
         'django_filters',
         'rest_framework',
+        'rest_framework_gis',
         'rest_framework_swagger',
         ]
 
@@ -60,6 +61,7 @@ else:
         'corsheaders',
         'django_filters',
         'rest_framework',
+        'rest_framework_gis',
         'rest_framework_swagger',
         ]
 


### PR DESCRIPTION
I noticed the extension that helps serialize geometry fields into geojson was included in the requirements but not the settings.