### PR TITLE
Script to set environment variables inside an ECS docker container during startup

### DIFF
--- a/DOCKERFILE.api.production
+++ b/DOCKERFILE.api.production
@@ -11,9 +11,6 @@ RUN apt-get update \
     libproj-dev \
   && apt-get clean
 
-# install awscli for get-ssm-parameters.sh script
-pip install --upgrade awscli
-
 # create and populate /code
 RUN mkdir /code
 WORKDIR /code

--- a/DOCKERFILE.api.production
+++ b/DOCKERFILE.api.production
@@ -11,6 +11,9 @@ RUN apt-get update \
     libproj-dev \
   && apt-get clean
 
+# install awscli for get-ssm-parameters.sh script
+pip install --upgrade awscli
+
 # create and populate /code
 RUN mkdir /code
 WORKDIR /code

--- a/bin/get-ssm-parameters.sh
+++ b/bin/get-ssm-parameters.sh
@@ -5,19 +5,13 @@
 
 # Modelled on https://aws.amazon.com/blogs/compute/managing-secrets-for-amazon-ecs-applications-using-parameter-store-and-iam-roles-for-tasks/
 
-EC2_REGION = "us-west-2" # unfortunately cannot rely on the env var values that this script is meant to pull in
-PROJECT_NAME = "disaster-resilience"
-
-#APP1_WITH_ENCRYPTION=`aws ssm get-parameters --names prod.app1.db-pass --with-decryption --region $EC2_REGION --output text 2>&1`
-#APP1_WITHOUT_ENCRYPTION=`aws ssm get-parameters --names prod.app1.db-pass --no-with-decryption --region $EC2_REGION --output text 2>&1`
-#LICENSE_WITH_ENCRYPTION=`aws ssm get-parameters --names general.license-code --with-decryption --region $EC2_REGION --output text 2>&1`
-#LICENSE_WITHOUT_ENCRYPTION=`aws ssm get-parameters --names general.license-code --no-with-decryption --region $EC2_REGION --output text 2>&1`
-#APP2_WITHOUT_ENCRYPTION=`aws ssm get-parameters --names prod.app2.user-name --no-with-decryption --region $EC2_REGION --output text 2>&1`
-
 # TODO:
 # 1. determine the values of the prefixes for each of the Parameter Store parameters (e.g. /production/2018/) that pass into the --names flag
 # 2. echo out the parameter values so they can be used by the container apps
 # 3. determine the best place to run this script so that it populates the env vars before they're needed by other code
+
+EC2_REGION = "us-west-2" # unfortunately cannot rely on dynamic env var values that this script is meant to pull in
+PROJECT_NAME = "disaster-resilience" # must be set to each project's "Final naming convention" from here https://github.com/hackoregon/civic-devops/issues/1
 
 # Get unencrypted values
 POSTGRES_HOST=`aws ssm get-parameters --names "/production/2018/API/$PROJECT_NAME/POSTGRES_HOST" --no-with-decryption --region $EC2_REGION --output text 2>&1`

--- a/bin/get-ssm-parameters.sh
+++ b/bin/get-ssm-parameters.sh
@@ -5,7 +5,8 @@
 
 # Modelled on https://aws.amazon.com/blogs/compute/managing-secrets-for-amazon-ecs-applications-using-parameter-store-and-iam-roles-for-tasks/
 
-EC2-REGION = "us-west-2" # unfortunately cannot rely on the env var values that this script is meant to pull in
+EC2_REGION = "us-west-2" # unfortunately cannot rely on the env var values that this script is meant to pull in
+PROJECT_NAME = "disaster-resilience"
 
 #APP1_WITH_ENCRYPTION=`aws ssm get-parameters --names prod.app1.db-pass --with-decryption --region $EC2_REGION --output text 2>&1`
 #APP1_WITHOUT_ENCRYPTION=`aws ssm get-parameters --names prod.app1.db-pass --no-with-decryption --region $EC2_REGION --output text 2>&1`
@@ -17,3 +18,21 @@ EC2-REGION = "us-west-2" # unfortunately cannot rely on the env var values that 
 # 1. determine the values of the prefixes for each of the Parameter Store parameters (e.g. /production/2018/) that pass into the --names flag
 # 2. echo out the parameter values so they can be used by the container apps
 # 3. determine the best place to run this script so that it populates the env vars before they're needed by other code
+
+# Get unencrypted values
+POSTGRES_HOST=`aws ssm get-parameters --names "/production/2018/API/$PROJECT_NAME/POSTGRES_HOST" --no-with-decryption --region $EC2_REGION --output text 2>&1`
+POSTGRES_NAME=`aws ssm get-parameters --names "/production/2018/API/$PROJECT_NAME/POSTGRES_NAME" --no-with-decryption --region $EC2_REGION --output text 2>&1`
+POSTGRES_PORT=`aws ssm get-parameters --names "/production/2018/API/$PROJECT_NAME/POSTGRES_PORT" --no-with-decryption --region $EC2_REGION --output text 2>&1`
+POSTGRES_USER=`aws ssm get-parameters --names "/production/2018/API/$PROJECT_NAME/POSTGRES_USER" --no-with-decryption --region $EC2_REGION --output text 2>&1`
+
+# Get encrypted values
+DJANGO_SECRET_KEY=`aws ssm get-parameters --names "/production/2018/API/$PROJECT_NAME/DJANGO_SECRET_KEY" --with-decryption --region $EC2_REGION --output text 2>&1`
+POSTGRES_PASSWORD=`aws ssm get-parameters --names "/production/2018/API/$PROJECT_NAME/POSTGRES_PASSWORD" --with-decryption --region $EC2_REGION --output text 2>&1`
+
+# Set environment variables in the container
+export DJANGO_SECRET_KEY=$DJANGO_SECRET_KEY
+export POSTGRES_HOST=$POSTGRES_HOST
+export POSTGRES_NAME=$POSTGRES_NAME
+export POSTGRES_PASSWORD=$POSTGRES_PASSWORD
+export POSTGRES_PORT=$POSTGRES_PORT
+export POSTGRES_USER=$POSTGRES_USER

--- a/bin/get-ssm-parameters.sh
+++ b/bin/get-ssm-parameters.sh
@@ -5,27 +5,20 @@
 
 # Modelled on https://aws.amazon.com/blogs/compute/managing-secrets-for-amazon-ecs-applications-using-parameter-store-and-iam-roles-for-tasks/
 
-# TODO:
-# 1. determine the values of the prefixes for each of the Parameter Store parameters (e.g. /production/2018/) that pass into the --names flag
-# 2. echo out the parameter values so they can be used by the container apps
-# 3. determine the best place to run this script so that it populates the env vars before they're needed by other code
-
-EC2_REGION = "us-west-2" # unfortunately cannot rely on dynamic env var values that this script is meant to pull in
-ENV_VAR_NAMESPACE = "/production/2018/API" # future-proofing this script for subsequent or past containers
-PROJECT_NAME = "disaster-resilience" # must be set to each project's "Final naming convention" from here https://github.com/hackoregon/civic-devops/issues/1
+EC2_REGION="us-west-2" # unfortunately cannot rely on dynamic env var values that this script is meant to pull in
+NAMESPACE="/production/2018/API" # future-proofing this script for subsequent or past containers
+PROJECT_CANONICAL_NAME="backend-exemplar" # must be set to each project's "Final naming convention" from here https://github.com/hackoregon/civic-devops/issues/1
 
 # Get unencrypted values
-POSTGRES_HOST=`aws ssm get-parameters --names "$ENV_VAR_NAMESPACE/$PROJECT_NAME/POSTGRES_HOST" --no-with-decryption --region $EC2_REGION --output text 2>&1`
-POSTGRES_NAME=`aws ssm get-parameters --names "$ENV_VAR_NAMESPACE/$PROJECT_NAME/POSTGRES_NAME" --no-with-decryption --region $EC2_REGION --output text 2>&1`
-POSTGRES_PORT=`aws ssm get-parameters --names "$ENV_VAR_NAMESPACE/$PROJECT_NAME/POSTGRES_PORT" --no-with-decryption --region $EC2_REGION --output text 2>&1`
-POSTGRES_USER=`aws ssm get-parameters --names "$ENV_VAR_NAMESPACE/$PROJECT_NAME/POSTGRES_USER" --no-with-decryption --region $EC2_REGION --output text 2>&1`
+POSTGRES_HOST=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_NAME"/POSTGRES_HOST --no-with-decryption --region $EC2_REGION --output text | awk '{print $4}'`
+POSTGRES_NAME=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_NAME"/POSTGRES_NAME --no-with-decryption --region $EC2_REGION --output text | awk '{print $4}'`
+POSTGRES_PORT=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_NAME"/POSTGRES_PORT --no-with-decryption --region $EC2_REGION --output text | awk '{print $4}'`
+POSTGRES_USER=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_NAME"/POSTGRES_USER --no-with-decryption --region $EC2_REGION --output text | awk '{print $4}'`
+PROJECT_CANONICAL_NAME=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_NAME"/PROJECT_NAME --no-with-decryption --region $EC2_REGION --output text | awk '{print $4}'`
 
 # Get encrypted values
-DJANGO_SECRET_KEY=`aws ssm get-parameters --names "$ENV_VAR_NAMESPACE/$PROJECT_NAME/DJANGO_SECRET_KEY" --with-decryption --region $EC2_REGION --output text 2>&1`
-POSTGRES_PASSWORD=`aws ssm get-parameters --names "$ENV_VAR_NAMESPACE/$PROJECT_NAME/POSTGRES_PASSWORD" --with-decryption --region $EC2_REGION --output text 2>&1`
-
-# Verify the values are coming through
-echo "database name is " $POSTGRES_NAME
+DJANGO_SECRET_KEY=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_NAME"/DJANGO_SECRET_KEY --with-decryption --region $EC2_REGION --output text | awk '{print $4}'`
+POSTGRES_PASSWORD=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_NAME"/POSTGRES_PASSWORD --with-decryption --region $EC2_REGION --output text | awk '{print $4}'`
 
 # Set environment variables in the container
 export DJANGO_SECRET_KEY=$DJANGO_SECRET_KEY
@@ -34,3 +27,4 @@ export POSTGRES_NAME=$POSTGRES_NAME
 export POSTGRES_PASSWORD=$POSTGRES_PASSWORD
 export POSTGRES_PORT=$POSTGRES_PORT
 export POSTGRES_USER=$POSTGRES_USER
+export PROJECT_CANONICAL_NAME=$PROJECT_CANONICAL_NAME

--- a/bin/get-ssm-parameters.sh
+++ b/bin/get-ssm-parameters.sh
@@ -11,17 +11,18 @@
 # 3. determine the best place to run this script so that it populates the env vars before they're needed by other code
 
 EC2_REGION = "us-west-2" # unfortunately cannot rely on dynamic env var values that this script is meant to pull in
+ENV_VAR_NAMESPACE = "/production/2018/API" # future-proofing this script for subsequent or past containers
 PROJECT_NAME = "disaster-resilience" # must be set to each project's "Final naming convention" from here https://github.com/hackoregon/civic-devops/issues/1
 
 # Get unencrypted values
-POSTGRES_HOST=`aws ssm get-parameters --names "/production/2018/API/$PROJECT_NAME/POSTGRES_HOST" --no-with-decryption --region $EC2_REGION --output text 2>&1`
-POSTGRES_NAME=`aws ssm get-parameters --names "/production/2018/API/$PROJECT_NAME/POSTGRES_NAME" --no-with-decryption --region $EC2_REGION --output text 2>&1`
-POSTGRES_PORT=`aws ssm get-parameters --names "/production/2018/API/$PROJECT_NAME/POSTGRES_PORT" --no-with-decryption --region $EC2_REGION --output text 2>&1`
-POSTGRES_USER=`aws ssm get-parameters --names "/production/2018/API/$PROJECT_NAME/POSTGRES_USER" --no-with-decryption --region $EC2_REGION --output text 2>&1`
+POSTGRES_HOST=`aws ssm get-parameters --names "$ENV_VAR_NAMESPACE/$PROJECT_NAME/POSTGRES_HOST" --no-with-decryption --region $EC2_REGION --output text 2>&1`
+POSTGRES_NAME=`aws ssm get-parameters --names "$ENV_VAR_NAMESPACE/$PROJECT_NAME/POSTGRES_NAME" --no-with-decryption --region $EC2_REGION --output text 2>&1`
+POSTGRES_PORT=`aws ssm get-parameters --names "$ENV_VAR_NAMESPACE/$PROJECT_NAME/POSTGRES_PORT" --no-with-decryption --region $EC2_REGION --output text 2>&1`
+POSTGRES_USER=`aws ssm get-parameters --names "$ENV_VAR_NAMESPACE/$PROJECT_NAME/POSTGRES_USER" --no-with-decryption --region $EC2_REGION --output text 2>&1`
 
 # Get encrypted values
-DJANGO_SECRET_KEY=`aws ssm get-parameters --names "/production/2018/API/$PROJECT_NAME/DJANGO_SECRET_KEY" --with-decryption --region $EC2_REGION --output text 2>&1`
-POSTGRES_PASSWORD=`aws ssm get-parameters --names "/production/2018/API/$PROJECT_NAME/POSTGRES_PASSWORD" --with-decryption --region $EC2_REGION --output text 2>&1`
+DJANGO_SECRET_KEY=`aws ssm get-parameters --names "$ENV_VAR_NAMESPACE/$PROJECT_NAME/DJANGO_SECRET_KEY" --with-decryption --region $EC2_REGION --output text 2>&1`
+POSTGRES_PASSWORD=`aws ssm get-parameters --names "$ENV_VAR_NAMESPACE/$PROJECT_NAME/POSTGRES_PASSWORD" --with-decryption --region $EC2_REGION --output text 2>&1`
 
 # Verify the values are coming through
 echo "database name is " $POSTGRES_NAME

--- a/bin/get-ssm-parameters.sh
+++ b/bin/get-ssm-parameters.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+# Pulls in HackO API env var values as parameters from AWS Parameter Store
+# Depends on pre-installed awscli
+

--- a/bin/get-ssm-parameters.sh
+++ b/bin/get-ssm-parameters.sh
@@ -14,7 +14,9 @@ POSTGRES_HOST=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_N
 POSTGRES_NAME=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_NAME"/POSTGRES_NAME --no-with-decryption --region $EC2_REGION --output text | awk '{print $4}'`
 POSTGRES_PORT=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_NAME"/POSTGRES_PORT --no-with-decryption --region $EC2_REGION --output text | awk '{print $4}'`
 POSTGRES_USER=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_NAME"/POSTGRES_USER --no-with-decryption --region $EC2_REGION --output text | awk '{print $4}'`
-PROJECT_CANONICAL_NAME=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_NAME"/PROJECT_NAME --no-with-decryption --region $EC2_REGION --output text | awk '{print $4}'`
+
+# Note: this env var value is for the WSGI startup - corresponds to the folder name where the base Django project is stored in the repo
+PROJECT_NAME=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_NAME"/PROJECT_NAME --no-with-decryption --region $EC2_REGION --output text | awk '{print $4}'`
 
 # Get encrypted values
 DJANGO_SECRET_KEY=`aws ssm get-parameters --names "$NAMESPACE"/"$PROJECT_CANONICAL_NAME"/DJANGO_SECRET_KEY --with-decryption --region $EC2_REGION --output text | awk '{print $4}'`
@@ -27,4 +29,4 @@ export POSTGRES_NAME=$POSTGRES_NAME
 export POSTGRES_PASSWORD=$POSTGRES_PASSWORD
 export POSTGRES_PORT=$POSTGRES_PORT
 export POSTGRES_USER=$POSTGRES_USER
-export PROJECT_CANONICAL_NAME=$PROJECT_CANONICAL_NAME
+export PROJECT_NAME=$PROJECT_NAME

--- a/bin/get-ssm-parameters.sh
+++ b/bin/get-ssm-parameters.sh
@@ -3,3 +3,17 @@
 # Pulls in HackO API env var values as parameters from AWS Parameter Store
 # Depends on pre-installed awscli
 
+# Modelled on https://aws.amazon.com/blogs/compute/managing-secrets-for-amazon-ecs-applications-using-parameter-store-and-iam-roles-for-tasks/
+
+EC2-REGION = "us-west-2" # unfortunately cannot rely on the env var values that this script is meant to pull in
+
+#APP1_WITH_ENCRYPTION=`aws ssm get-parameters --names prod.app1.db-pass --with-decryption --region $EC2_REGION --output text 2>&1`
+#APP1_WITHOUT_ENCRYPTION=`aws ssm get-parameters --names prod.app1.db-pass --no-with-decryption --region $EC2_REGION --output text 2>&1`
+#LICENSE_WITH_ENCRYPTION=`aws ssm get-parameters --names general.license-code --with-decryption --region $EC2_REGION --output text 2>&1`
+#LICENSE_WITHOUT_ENCRYPTION=`aws ssm get-parameters --names general.license-code --no-with-decryption --region $EC2_REGION --output text 2>&1`
+#APP2_WITHOUT_ENCRYPTION=`aws ssm get-parameters --names prod.app2.user-name --no-with-decryption --region $EC2_REGION --output text 2>&1`
+
+# TODO:
+# 1. determine the values of the prefixes for each of the Parameter Store parameters (e.g. /production/2018/) that pass into the --names flag
+# 2. echo out the parameter values so they can be used by the container apps
+# 3. determine the best place to run this script so that it populates the env vars before they're needed by other code

--- a/bin/get-ssm-parameters.sh
+++ b/bin/get-ssm-parameters.sh
@@ -23,6 +23,9 @@ POSTGRES_USER=`aws ssm get-parameters --names "/production/2018/API/$PROJECT_NAM
 DJANGO_SECRET_KEY=`aws ssm get-parameters --names "/production/2018/API/$PROJECT_NAME/DJANGO_SECRET_KEY" --with-decryption --region $EC2_REGION --output text 2>&1`
 POSTGRES_PASSWORD=`aws ssm get-parameters --names "/production/2018/API/$PROJECT_NAME/POSTGRES_PASSWORD" --with-decryption --region $EC2_REGION --output text 2>&1`
 
+# Verify the values are coming through
+echo "database name is " $POSTGRES_NAME
+
 # Set environment variables in the container
 export DJANGO_SECRET_KEY=$DJANGO_SECRET_KEY
 export POSTGRES_HOST=$POSTGRES_HOST

--- a/bin/production-docker-entrypoint.sh
+++ b/bin/production-docker-entrypoint.sh
@@ -6,8 +6,9 @@ set -e
 
 echo Debug: $DEBUG
 
-# Pull in environment variables values from AWS Parameter Store
-/code/bin/get-ssm-parameters.sh
+# Pull in environment variables values from AWS Parameter Store, and preserve the exports
+# source usage per https://stackoverflow.com/q/14742358/452120
+source /code/bin/get-ssm-parameters.sh
 
 python -Wall manage.py collectstatic --noinput
 

--- a/bin/production-docker-entrypoint.sh
+++ b/bin/production-docker-entrypoint.sh
@@ -6,6 +6,9 @@ set -e
 
 echo Debug: $DEBUG
 
+# Pull in environment variables values from AWS Parameter Store
+/code/bin/get-ssm-parameters.sh
+
 python -Wall manage.py collectstatic --noinput
 
 gunicorn $PROJECT_NAME.wsgi -c gunicorn_config.py

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,3 +8,6 @@ gevent==1.3a1
  # DB connector for Green Connections
 psycogreen==1.0
 django-db-geventpool
+
+# install for use by get-ssm-parameters.sh script
+awscli


### PR DESCRIPTION
This script is needed to pull in environment variable values from a dynamic store in AWS called Parameter Store (see #113), so that when a Docker container is launched on its own in the AWS ECS environment, it can fill in (mainly) the database connection parameters.

Script is intended to set the named environment variables early in the Docker container startup, so that the env vars will be available by the time their values get read during start of the API application.

Script has not been tested since it depends on certain roles and policies that are only assigned to AWS ECS containers.

## ToDo:
- [x] Place a call to this script in the appropriate place in the Docker container startup
- [x] Confirm that it's possible to `pip install awscli` in our container without having to first install Python - or alternatively, to find another less burdensome way to install `awscli`
- [x] Test this by deploying one project's container and see whether the container stays up (or debug in production, since there's probably no way to test this outside an ECS environment)