### PR TITLE
use non-psycopg2 db driver to fix depecration warning

### DIFF
--- a/dead_songs/settings.py
+++ b/dead_songs/settings.py
@@ -101,7 +101,7 @@ WSGI_APPLICATION = 'dead_songs.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'ENGINE': 'django.db.backends.postgresql',
         'PASSWORD': os.environ.get('POSTGRES_PASSWORD'),
         'NAME': os.environ.get('POSTGRES_NAME'),
         'USER': os.environ.get('POSTGRES_USER'),


### PR DESCRIPTION
psycopg2 db driver for postgres is depecrated, use included driver instead